### PR TITLE
Fix: Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+name: orders-api
 
 services:
   orders_api:
@@ -8,10 +8,11 @@ services:
       context: .
       dockerfile: Dockerfile
     depends_on:
-      - orders_db
+      orders_db:
+        condition: service_healthy
     environment:
       DB_ENDPOINT: orders_db:5432
-      DB_NAME: selforder
+      DB_NAME: orders
       DB_USERNAME: selforder
       DB_PASSWORD: self@Order123!
       ADMIN_ACCESS_TOKEN: token
@@ -20,6 +21,11 @@ services:
     ports:
       - "8080:8080"
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   orders_db:
     image: postgres:15.4
@@ -33,7 +39,11 @@ services:
     ports:
       - "5434:5432"
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   orders_db:
-    driver: local


### PR DESCRIPTION
Before:
```bash
orders_api  | Caused by: org.flywaydb.core.internal.exception.FlywaySqlException: Unable to obtain connection from database: FATAL: database "selforder" does not exist
orders_api  | -------------------------------------------------------------------------------------
orders_api  | SQL State  : 3D000
orders_api  | Error Code : 0
orders_api  | Message    : FATAL: database "selforder" does not exist
```
After:
```bash
NAME         IMAGE                              COMMAND                  SERVICE      CREATED          STATUS                    PORTS
orders_api   fiap-3soat-g15-orders-api:latest   "java -jar app.jar"      orders_api   26 seconds ago   Up 14 seconds (healthy)   0.0.0.0:8080->8080/tcp
orders_db    postgres:15.4                      "docker-entrypoint.s…"   orders_db    26 seconds ago   Up 25 seconds (healthy)   0.0.0.0:5434->5432/tcp
```